### PR TITLE
Keep -std=gnu++11 in stm32 build_unflags

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -380,7 +380,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/STM32>
 platform      = ${common_stm32.platform}
 build_flags   = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags} -std=gnu++14 -DHAVE_SW_SERIAL
-build_unflags = -std=gnu11
+build_unflags = -std=gnu11 -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_ignore    = SPI
 lib_deps      = ${common.lib_deps}


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
